### PR TITLE
Updating maven liberty plugin to 1.1 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <licenses>
       <license>
           <name>The Apache Software License, Version 2.0</name>
-          <url>https://raw.github.com/WASdev/sample.microservices.12factorapp/master/LICENSE</url>
+          <url>https://raw.github.com/WASdev/sample.rtcomm.healthcare/master/LICENSE</url>
           <distribution>repo</distribution>
       </license>
   </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
           <distribution>repo</distribution>
       </license>
   </licenses>
-  
+
   <properties>
     <!-- Specify Liberty profile server installation directory -->
     <wlp.install.dir></wlp.install.dir>
@@ -104,7 +104,7 @@
                  <pluginExecutionFilter>
                    <groupId>net.wasdev.wlp.maven.plugins</groupId>
                    <artifactId>liberty-maven-plugin</artifactId>
-                   <versionRange>[1.1-SNAPSHOT,)</versionRange>
+                   <versionRange>[1.1,)</versionRange>
                    <goals>
                      <goal>install-feature</goal>
                      <goal>create-server</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                  <pluginExecutionFilter>
                    <groupId>net.wasdev.wlp.maven.plugins</groupId>
                    <artifactId>liberty-maven-plugin</artifactId>
-                   <versionRange>[1.1,)</versionRange>
+                   <versionRange>[1.2-SNAPSHOT,)</versionRange>
                    <goals>
                      <goal>install-feature</goal>
                      <goal>create-server</goal>

--- a/rtcomm.healthcare.wlpcfg/pom.xml
+++ b/rtcomm.healthcare.wlpcfg/pom.xml
@@ -48,7 +48,7 @@
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <extensions>true</extensions>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.1</version>
 
         <configuration>
           <installDirectory>${wlp.install.dir}</installDirectory>

--- a/rtcomm.healthcare.wlpcfg/pom.xml
+++ b/rtcomm.healthcare.wlpcfg/pom.xml
@@ -48,7 +48,7 @@
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <extensions>true</extensions>
-        <version>1.1</version>
+        <version>1.2-SNAPSHOT</version>
 
         <configuration>
           <installDirectory>${wlp.install.dir}</installDirectory>


### PR DESCRIPTION
The ci.maven project from WASdev released a new version of the plugin (1.0 -> 1.1). Consequently the current version in the pom.xml (1.1-SNAPSHOT) isn't working and it breaks the sample. This pull request will fix the project.
